### PR TITLE
python: Handle ValueError raised by str.index() more gracefully

### DIFF
--- a/python/depthcharge/uboot/env.py
+++ b/python/depthcharge/uboot/env.py
@@ -93,7 +93,11 @@ def parse(text: str) -> dict:
             if not line or line.startswith('Environment size: '):
                 continue
 
-            delim_idx = line.index('=')
+            try:
+                delim_idx = line.index('=')
+            except ValueError:
+                # Try to be resilient and ignore bizzare or malformed lines...
+                continue
 
             name  = line[:delim_idx]
             value = line[delim_idx+1:]


### PR DESCRIPTION
We should be emitting this error in a more meaningful way at the
end if we can't identify the environment.

Allowing str.index() to bubble up is not useful to a user.
We'll just skip bogus lines and try to gather what we can.