### PR TITLE
python: Convert log.info instances to log.note

### DIFF
--- a/python/depthcharge/companion.py
+++ b/python/depthcharge/companion.py
@@ -186,7 +186,7 @@ class Companion:
         if addr not in range(0, 0x80):
             raise ValueError('Invalid address: 0x{:02x}'.format(addr))
 
-        log.info('Setting Companion I2C device address to 0x{:02x}'.format(addr))
+        log.note('Setting Companion I2C device address to 0x{:02x}'.format(addr))
         self.send_cmd('i2c_set_addr', addr.to_bytes(1, 'big'), 1, self._status_ok)
 
         self._i2c_addr = addr
@@ -219,7 +219,7 @@ class Companion:
             err = 'Speed outside of supported range: {:d} Hz'.format(speed)
             raise ValueError(err)
 
-        log.info('Setting Companion I2C bus speed to {:d} Hz'.format(speed))
+        log.note('Setting Companion I2C bus speed to {:d} Hz'.format(speed))
 
         self.send_cmd('i2c_set_speed', speed.to_bytes(4, 'little'), 1, self._status_ok)
         self._i2c_speed = speed

--- a/python/depthcharge/console.py
+++ b/python/depthcharge/console.py
@@ -81,7 +81,7 @@ class Console:
                 + self._reboot_re.pattern + '\n'
                 + '    Will use this command: ' + self._reboot_cmd
             )
-            log.info(msg)
+            log.note(msg)
 
         # We're going to pass this off to the Serial constructor in a moment.
         if 'baudrate' not in kwargs:
@@ -163,7 +163,7 @@ class Console:
         self._ser.flush()
 
         if self.prompt is None or len(self.prompt) == 0:
-            log.info('No user-specified prompt provided. Attempting to determine this.')
+            log.note('No user-specified prompt provided. Attempting to determine this.')
             return self.discover_prompt(interrupt_str, timeout)
 
         ret = ''
@@ -223,12 +223,12 @@ class Console:
                         candidate = ''
                         candidate_count = 0
                         msg = 'Attempting reboot. Matched reboot regex: ' + response_stripped
-                        log.info(msg)
+                        log.note(msg)
                         self.write(self._reboot_cmd + '\n')
                         self._ser.flush()
 
                     if candidate_count > 0:
-                        log.info('Identified prompt: ' + response)
+                        log.note('Identified prompt: ' + response)
                         self.prompt = response
                         return ret
             else:

--- a/python/depthcharge/context.py
+++ b/python/depthcharge/context.py
@@ -258,7 +258,7 @@ class Depthcharge:
         # stomping on stuff that we actively may wish to tamper wtih.
         self._payload_base = kwargs.get('payload_base', 'loadaddr')
         if 'payload_base' not in kwargs:  # We used the loadaddr default...
-            log.info('Using default payload base address: ${loadaddr} + 32MiB')
+            log.note('Using default payload base address: ${loadaddr} + 32MiB')
             self._payload_off = 32 * 1024 * 1024
         else:
             self._payload_off = kwargs.get('payload_offset', 0)
@@ -341,7 +341,7 @@ class Depthcharge:
 
         msg = 'Depthcharge payload base (0x{:08x}) + payload offset (0x{:08x}) => 0x{:08x}'
         actual_base = self._payload_base + self._payload_off
-        log.info(msg.format(self._payload_base, self._payload_off, actual_base))
+        log.note(msg.format(self._payload_base, self._payload_off, actual_base))
         return actual_base
 
     @staticmethod
@@ -562,7 +562,7 @@ class Depthcharge:
         Serialize the current configuration of the current Depthcharge context
         to a JSON object and write it to the provided filename.
         """
-        log.info('Saving depthcharge configuration state to ' + filename)
+        log.note('Saving depthcharge configuration state to ' + filename)
         s = self.to_json(timestamp, comment)
         with open(filename, 'w') as outfile:
             outfile.write(s)
@@ -826,7 +826,7 @@ class Depthcharge:
             resp = self.console.send_command('version')
             self._version = resp.splitlines()
             if len(self._version) >= 1:
-                log.info('Version: ' + self._version[0])
+                log.note('Version: ' + self._version[0])
             return self._version
 
         if 'reset' in self._cmds and allow_reset:
@@ -836,7 +836,7 @@ class Depthcharge:
             for line in lines:
                 if self._ver_re.match(line):
                     self._version = [line.strip()]
-                    log.info('Version: ' + self._version[0])
+                    log.note('Version: ' + self._version[0])
                     return self._version
 
             log.warning('Did not see U-Boot version string. Old or non-standard version format?')
@@ -1141,7 +1141,7 @@ class Depthcharge:
             return
 
         if not deployed or force:
-            log.info('Deploying payload \"{:s}\" @ 0x{:08x}'.format(name, addr))
+            log.note('Deploying payload \"{:s}\" @ 0x{:08x}'.format(name, addr))
             self.write_memory(addr, payload['data'])
             self._payloads.mark_deployed(name)
 
@@ -1247,11 +1247,11 @@ class Depthcharge:
 
         if already_applied == len(patch_list):
             msg = 'Target memory appears to be already patched. No writes needed.'
-            log.info(msg)
+            log.note(msg)
             return False
 
         msg = 'Target memory appears to have been only partially patched.'
-        log.info(msg)
+        log.note(msg)
         return True
 
     def uboot_global_data(self, cached=True, **kwargs) -> dict:
@@ -1346,7 +1346,7 @@ class Depthcharge:
 
             self._gd['address'] = register_reader.read(gd_reg)
             msg = 'Located U-boot global data structure (*gd) @ 0x{:08x}'
-            log.info(msg.format(self._gd['address']))
+            log.note(msg.format(self._gd['address']))
             return self._gd['address']
 
     def _uboot_jump_table(self, memory_reader=None):

--- a/python/depthcharge/hunter/revcrc32.py
+++ b/python/depthcharge/hunter/revcrc32.py
@@ -522,7 +522,7 @@ class ReverseCRC32Hunter(Hunter):
         msg += '{:d} entries, {:d} total operations, largest operation is {:d} iterations'
         payload_name = ' from ' + kwargs.get('payload_name') if 'payload_name' in kwargs else ''
         msg = msg.format(payload_name, str(t_elapsed), n_entries, total_ops, max_iter)
-        log.info(msg)
+        log.note(msg)
 
         stratagem.comment = msg
         return stratagem

--- a/python/tests/integration/launch_scripts.py
+++ b/python/tests/integration/launch_scripts.py
@@ -58,7 +58,7 @@ def locate_scripts() -> dict:
 
     """
     script_dir = realpath(os.path.join(_THIS_DIR, '../../scripts'))
-    log.info('Searching for scripts in: ' + script_dir)
+    log.note('Searching for scripts in: ' + script_dir)
 
     ret = {}
     for root, _, files in os.walk(script_dir):
@@ -516,7 +516,7 @@ def test_read_mem__uboot(state: dict, script: str):
     state['uboot_bin_file'] = os.path.join(state['test_dir'], 'uboot_512K.bin')
     uboot_addr = state['config']['gd']['bd']['relocaddr']['value']
 
-    log.info('Reading 512K of U-Boot code/data to a binary file')
+    log.note('Reading 512K of U-Boot code/data to a binary file')
 
     args = [
         script,
@@ -788,14 +788,20 @@ if __name__ == '__main__':
 
     for test in tests:
         script = test_name_to_script(test.__name__)
-        log.info('Running ' + test.__name__)
+        log.note('Running ' + test.__name__)
         test_help(state, script)
         test(state, script)
         save_state(state)
 
     t_end = time.time()
     t_elapsed = timedelta(seconds=(t_end - t_start))
-    print(os.linesep + '=' * 76)
-    print('Tests complete successfully.')
-    print('Elapsed: ' + str(t_elapsed))
-    print()
+
+    msg = (
+        '=' * 76 + os.linesep +
+        '  Tests complete successfully.' +
+        os.linesep +
+        '  Elapsed: ' + str(t_elapsed) +
+        os.linesep
+    )
+
+    log.info(msg)


### PR DESCRIPTION
log.info() is more useful when used sparingly to denote "interesting"
observations and successes in top-level script code.

In the future I need to remember to re-iterate this in some sort
of Depthcharge Developer's Guide.