### PR TITLE
memory: More lenient hex dump output matching

### DIFF
--- a/python/depthcharge/memory/memcmds.py
+++ b/python/depthcharge/memory/memcmds.py
@@ -59,7 +59,7 @@ class MdMemoryReader(MemoryReader):
         ^
         (?P<addr>[0-9a-fA-F]{8,}):\s+       # Address prefix
         (?P<data>([0-9a-fA-F]+\s)+)         # Data words
-        \s+.{16}                            # ASCII representation
+        \s+.{1,16}                          # ASCII representation
     """, re.VERBOSE)
 
     @classmethod


### PR DESCRIPTION
The following was observed on a device running (a fork of) U-Boot 2012.10
when a small (word-wise) memory read was performed when validating an
applied MemoryPatch:

    depthcharge.operation.OperationFailed:
        Failed to parse line: bff64d92: f7ff ffd5    ....

This failure arises from our regular expression expecting 16 characters
in the ASCII section of the hex dump output, which clearly is not the
case here. (It seems newer versions pad up to a fixed line length.)

We now look for 1 to 16 characters. I don't recall U-Boot ever
outputting an address followed by an empty line, hence not {0, 16}.

Fixes #91