### PR TITLE
doc: Sphinx & RTD theme updates to fix doc rendering

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+2022-03-05: Depthcharge Bug Fix Update 0.3.2
+----------------------------------------------------------------------------
+
+Fixed documentation rendering issues resulting from usage of the new 1.0.0
+Sphinx RTD theme release and updated dependency specification accordingly.
+
+
 2022-03-05: Depthcharge Bug Fix Update 0.3.1
 ----------------------------------------------------------------------------
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2019-2020 NCC Group.
+Copyright (c) 2019-2022 NCC Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/doc/README.md
+++ b/doc/README.md
@@ -2,7 +2,7 @@
 
 
 This directory contains the source code for Depthcharge's documentation.  
-If you're just looking for documentatoin to reference, see 
+If you're just looking for documentation to reference, see 
 <https://depthcharge.readthedocs.io>.
 
 ## Dependencies
@@ -23,7 +23,7 @@ only in your virtual environment.
 
 ## Build
 
-With the above dependancies satisfied, the documentation can be created by running:
+With the above dependencies satisfied, the documentation can be created by running:
 
 ```
 $ make html

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -11,7 +11,7 @@ import depthcharge
 # -- Project information -----------------------------------------------------
 
 project = 'Depthcharge'
-copyright = '2019-2020, NCC Group.'
+copyright = '2019-2022, NCC Group.'
 author = 'Jon Szymaniak (NCC Group)'
 
 # The full version, including alpha/beta/rc tags
@@ -23,7 +23,8 @@ release = depthcharge.__version__
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc'
+    'sphinx.ext.autodoc',
+    'sphinx_rtd_theme'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -41,16 +42,11 @@ autodoc_member_order = 'bysource'
 html_static_path = ['_static']
 
 # Apply RTD theme overrides
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css'
-    ],
-}
+html_css_files = ['theme_overrides.css']
 
 html_logo = '../images/depthcharge-500.png'
 
 html_theme = 'sphinx_rtd_theme'
-
 html_theme_options = {
     'logo_only': True
 }

--- a/python/depthcharge/version.py
+++ b/python/depthcharge/version.py
@@ -1,4 +1,4 @@
 """
 Depthcharge Python module version
 """
-__version__ = '0.3.1'
+__version__ = '0.3.2'

--- a/python/setup.py
+++ b/python/setup.py
@@ -82,7 +82,7 @@ setup(
     python_requires='>=3.6, <4',
 
     extras_require={
-        'docs': ['sphinx>=3.0.0', 'sphinx_rtd_theme>=0.4.0']
+        'docs': ['sphinx>=4.4.0', 'sphinx_rtd_theme >=1.0.0, <2.0.0']
     },
 
     zip_safe=False,


### PR DESCRIPTION
Documentation config changes were necessary to account
for backwards incompatible changes introduced by the
sphinx_rtd_theme 1.0.0 release.

Updated [docs] extra dependencies versions accordingly,
to the latest and greatest.

Copyright year updates and typo fixes also included.